### PR TITLE
Refactor project date fields for consistency

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,6 +1,3 @@
-// src/data/projects.ts
-
-// Define the structure for a project
 export interface Project {
     // Basic information every project should have
     title: string;
@@ -11,7 +8,7 @@ export interface Project {
     category: 'software' | 'music' | 'education';
     featured: boolean;  // Indicates if this should appear on the home page
     status: 'in-progress' | 'completed' | 'planned';
-    dateAdded: string;
+    datePublished: string;
     lastUpdated?: string;
 
     // Optional detailed information
@@ -36,7 +33,7 @@ export const projects: Project[] = [
         category: "software",
         featured: true,
         status: "in-progress",
-        dateAdded: "2024-02-20",
+        datePublished: "2024-02-20",
         lastUpdated: "2024-02-20",
         tags: ["Music Theory", "Piano"],
         technologies: ["Godot", "GDScript", "MIDI",],
@@ -54,18 +51,19 @@ export const projects: Project[] = [
         category: "education",
         featured: true,
         status: "completed",
-        dateAdded: "2025-02-20",
+        datePublished: "2023-11-13",
         tags: ["Dart", "Textbook", "Education"],
         technologies: ["JavaScript", "Markdown", "Quarto", "GitHub Pages"],
     },
     {
         title: "Tides of Change",
-        description: "A collection of ambient music pieces exploring the intersection of electronic and traditional musical elements.",
+        description: "This instrumental album offers a mix of peaceful piano melodies, heartfelt folk tunes, and darker electronic soundscapes, creating a journey of varied moods for quiet listening.",
+        longDescription: "This album is a diverse collection of instrumental pieces exploring a range of emotions and sonic landscapes. From the gentle, reflective piano melodies of classical influence and serene folk ballads featuring acoustic instruments, to darker, more experimental electronic tracks with industrial and ambient textures, the album journeys through melancholic introspection, heartfelt yearning, and unsettling atmospheres. It showcases a blend of acoustic and electronic instrumentation, unified by a focus on evocative mood creation and atmospheric depth, perfect for cinematic soundscapes and introspective listening.",
         url: "https://soundcloud.com/brylie/sets/tides-of-change",
         category: "music",
         featured: true,
         status: "completed",
-        dateAdded: "2025-02-20",
+        datePublished: "2024-11-17",
         tags: ["Ambient", "Electronic", "Orchestral"]
     },
     // SoundCloud album: https://soundcloud.com/brylie/sets/murmurations
@@ -76,7 +74,7 @@ export const projects: Project[] = [
         category: "music",
         featured: true,
         status: "completed",
-        dateAdded: "2024-07-31",
+        datePublished: "2024-07-31",
         tags: ["Ambient", "Electronic", "Orchestral"]
     }
 ];
@@ -85,17 +83,17 @@ export const projects: Project[] = [
 export function getFeaturedProjects(): Project[] {
     return projects
         .filter(project => project.featured)
-        .sort((a, b) => new Date(b.dateAdded).getTime() - new Date(a.dateAdded).getTime());
+        .sort((a, b) => new Date(b.datePublished).getTime() - new Date(a.datePublished).getTime());
 }
 
 export function getProjectsByCategory(category: Project['category']): Project[] {
     return projects
         .filter(project => project.category === category)
-        .sort((a, b) => new Date(b.dateAdded).getTime() - new Date(a.dateAdded).getTime());
+        .sort((a, b) => new Date(b.datePublished).getTime() - new Date(a.datePublished).getTime());
 }
 
 export function getAllProjects(): Project[] {
     return [...projects].sort((a, b) =>
-        new Date(b.dateAdded).getTime() - new Date(a.dateAdded).getTime()
+        new Date(b.datePublished).getTime() - new Date(a.datePublished).getTime()
     );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,11 +69,11 @@ const categoryConfig = {
 											{project.category}
 										</span>
 										<time
-											datetime={project.dateAdded}
+											datetime={project.datePublished}
 											class="text-sm text-gray-500"
 										>
 											{new Date(
-												project.dateAdded,
+												project.datePublished,
 											).toLocaleDateString("en-US", {
 												month: "short",
 												year: "numeric",


### PR DESCRIPTION
Change all instances of 'dateAdded' to 'datePublished' to ensure uniformity across the project data structure.